### PR TITLE
fix: use getFlagCode for flag classname in combo

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/localecombobox/LocaleComboBox.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/localecombobox/LocaleComboBox.java
@@ -211,7 +211,7 @@ public class LocaleComboBox extends ComboBox<Locale> {
     }
 
     Span flagIcon = new Span();
-    flagIcon.addClassNames("fi", "fi-" + locale.getCountry().toLowerCase());
+    flagIcon.addClassNames("fi", "fi-" + this.getFlagCode(locale));
     setPrefixComponent(flagIcon);
   }
 


### PR DESCRIPTION
fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved flag icon representation in the LocaleComboBox by enhancing the logic for generating flag class names based on locale.
- **Refactor**
	- Abstracted flag code determination into a separate method for better maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->